### PR TITLE
feat: library 마이그레이션

### DIFF
--- a/apps/member/src/components/common/Skeleton/SkeletonImage.tsx
+++ b/apps/member/src/components/common/Skeleton/SkeletonImage.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import classNames from 'classnames';
+
+interface SkeletonImageProps {
+  src: string;
+  alt: string;
+  className: string;
+  w?: number | string;
+  h?: number | string;
+  onClick?: React.MouseEventHandler<HTMLImageElement>;
+}
+const SkeletonImage = ({
+  src,
+  alt,
+  className,
+  w = 'auto',
+  h = 'auto',
+  onClick,
+}: SkeletonImageProps) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const width = w && `w-[${w}px]`;
+  const height = h && `h-[${h}px]`;
+
+  const handleError = () => {
+    setError(true);
+    setLoading(false);
+  };
+
+  if (error) {
+    return (
+      <img
+        className={classNames('bg-gray-50', className, width, height, {
+          'cursor-pointer': onClick,
+        })}
+        src="/not_found_preview.webp"
+        alt={alt}
+        onClick={onClick}
+      />
+    );
+  }
+
+  return (
+    <img
+      className={classNames(className, width, height, {
+        'animate-pulse bg-gray-100': loading,
+        'cursor-pointer': onClick,
+      })}
+      src={src}
+      alt={alt}
+      onClick={onClick}
+      onLoad={() => setLoading(false)}
+      onError={handleError}
+    />
+  );
+};
+
+export default SkeletonImage;

--- a/apps/member/src/components/library/BookDetailSection/BookDetailSection.tsx
+++ b/apps/member/src/components/library/BookDetailSection/BookDetailSection.tsx
@@ -1,0 +1,83 @@
+import Button from '@components/common/Button/Button';
+import Section from '@components/common/Section/Section';
+import SkeletonImage from '@components/common/Skeleton/SkeletonImage';
+import { Link } from 'react-router-dom';
+
+interface BookDetailSectionProps {
+  data: {
+    title: string;
+    image: string;
+    author: string;
+    publisher: string;
+    category: string;
+    date: string;
+    detail: string;
+    state: string;
+  };
+}
+
+const BookDetailSection = ({ data }: BookDetailSectionProps) => {
+  return (
+    <Section>
+      <div className="flex flex-col gap-2 px-2">
+        <div className="my-4 gap-4 lg:grid lg:grid-cols-2">
+          {/*  책 표지 */}
+          <div className="md:mb-4 lg:m-0 lg:max-w-3xl">
+            <SkeletonImage
+              src={data.image}
+              className="h-auto w-[380px] object-cover shadow-xl border"
+              alt="도서 이미지"
+              w={380}
+              h="auto"
+            />
+          </div>
+
+          {/* 책 정보 */}
+          <div className="flex flex-col gap-4 justify-between">
+            <div className="space-y-2">
+              <h1 className="text-2xl font-bold pb-4">{data.title}</h1>
+              <div className="flex">
+                <p className="pr-2 font-bold">작가</p>
+                <p>{data.author}</p>
+              </div>
+              <div className="flex">
+                <p className="pr-2 font-bold">출판사</p>
+                <p>{data.publisher}</p>
+              </div>
+              <div className="flex">
+                <p className="pr-2 font-bold">출간일</p>
+                <p>{data.date}</p>
+              </div>
+              <div className="flex">
+                <p className="pr-2 font-bold">분류</p>
+                <p>{data.category}</p>
+              </div>
+              <div className="flex">
+                <p className="pr-2 font-bold">대여 상태</p>
+                <p>{data.state}</p>
+              </div>
+              <div className="flex">
+                <p className="pr-2 font-bold">상세 정보</p>
+                <Link to={data.detail}>교보문구</Link>
+              </div>
+            </div>
+
+            <div className="w-full">
+              {data?.state === '대여 가능' ? (
+                <Button className="w-full mt-4 bg-clab-main text-white hover:bg-clab-main-dark">
+                  대여하기
+                </Button>
+              ) : (
+                <p className="text-xl font-bold pt-12 underline decoration-green-700">
+                  이미 대여된 도서예요! 조금만 기다려주세요 ⏳
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default BookDetailSection;

--- a/apps/member/src/components/library/LibraryBookList/LibraryBookList.tsx
+++ b/apps/member/src/components/library/LibraryBookList/LibraryBookList.tsx
@@ -1,0 +1,62 @@
+import SkeletonImage from '@components/common/Skeleton/SkeletonImage';
+import { PATH_FINDER } from '@constants/path';
+import { useNavigate } from 'react-router-dom';
+
+interface LibraryBookListProps {
+  data: {
+    id: number;
+    title: string;
+    image: string;
+    author: string;
+    publisher: string;
+    state: string;
+  }[];
+  category: string;
+}
+
+const LibraryBookList = ({ data, category }: LibraryBookListProps) => {
+  const navigate = useNavigate();
+
+  const onClickBook = (id: number) => {
+    navigate(PATH_FINDER.LIBRARY_DETAIL(id), {
+      state: { id: id },
+    });
+  };
+
+  return (
+    <div className="grid gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {data.map(({ id, image, title, author, publisher, state }) => (
+        <div
+          key={id}
+          className="space-y-1 border rounded-lg cursor-pointer"
+          onClick={() => onClickBook(id)}
+        >
+          <SkeletonImage
+            className="h-[200px] w-full object-cover border-b"
+            src={image}
+            alt="도서 이미지"
+            h={200}
+            w={200}
+          />
+
+          <div className="text-sm p-2">
+            <p className="hover:underline font-bold">{title}</p>
+            <p className="text-gray-500">
+              {author} | {publisher}
+            </p>
+            {category === '소장도서' && (
+              <p
+                className={
+                  state === '대여 가능' ? 'text-green-600' : 'text-pink-600'
+                }
+              >
+                {state}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+export default LibraryBookList;

--- a/apps/member/src/components/library/LibraryNewBookSection/LibraryNewBookSection.tsx
+++ b/apps/member/src/components/library/LibraryNewBookSection/LibraryNewBookSection.tsx
@@ -1,0 +1,22 @@
+import Section from '@components/common/Section/Section';
+import LibraryBookList from '../LibraryBookList/LibraryBookList';
+import bookCollection from '@mocks/data/bookCollection.json';
+
+const LibraryNewBookSection = () => {
+  return (
+    <Section>
+      <Section.Header title="신작도서" />
+      <Section.Body>
+        <LibraryBookList
+          data={bookCollection.slice(
+            bookCollection.length - 3,
+            bookCollection.length,
+          )}
+          category="신작도서"
+        />
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default LibraryNewBookSection;

--- a/apps/member/src/components/library/LibraryOwnBookSection/LibraryOwnBookSection.tsx
+++ b/apps/member/src/components/library/LibraryOwnBookSection/LibraryOwnBookSection.tsx
@@ -1,0 +1,35 @@
+import Section from '@components/common/Section/Section';
+import LibraryBookList from '../LibraryBookList/LibraryBookList';
+import bookCollection from '@mocks/data/bookCollection.json';
+import { useState } from 'react';
+import Pagination from '@components/common/Pagination/Pagination';
+
+const LibraryNewBookSection = () => {
+  const [page, setPage] = useState(1);
+
+  const limit = 12;
+  const offset = (page - 1) * limit;
+
+  return (
+    <Section>
+      <Section.Header title="소장도서" />
+      <Section.Body>
+        <LibraryBookList
+          data={bookCollection.slice(offset, offset + limit)}
+          category="소장도서"
+        />
+        <div className="flex justify-center mt-4">
+          <Pagination
+            totalItems={bookCollection.length}
+            pageLimit={5}
+            postLimit={limit}
+            setPage={setPage}
+            page={page}
+          />
+        </div>
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default LibraryNewBookSection;

--- a/apps/member/src/constants/path.ts
+++ b/apps/member/src/constants/path.ts
@@ -17,6 +17,7 @@ export const PATH = {
   NEWS: '/news',
   BLOG: '/blog',
   LIBRARY: '/library',
+  LIBRARY_DETAIL: '/library/:id',
   SUPPORT: '/support',
   SITEMAP: '/sitemap',
 };
@@ -25,4 +26,5 @@ export const PATH_FINDER = {
   NEWS_POST: (id: number) => `${PATH.NEWS}/${id}`,
   BLOG_POST: (id: number) => `${PATH.BLOG}/${id}`,
   COMMUNITY_POST: (sort: string, id: number) => `/community/${sort}/${id}`,
+  LIBRARY_DETAIL: (id: number) => `/library/${id}`,
 };

--- a/apps/member/src/mocks/data/bookCollection.json
+++ b/apps/member/src/mocks/data/bookCollection.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": 1,
+    "title": "리액트를 다루는 기술",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791160508796.jpg",
+    "author": "김민준",
+    "publisher": "길벗",
+    "category": "개발",
+    "date": "2019-08-31",
+    "detail": "https://product.kyobobook.co.kr/detail/S000001792882",
+    "state": "대여 중",
+    "memberID": ""
+  },
+  {
+    "id": 2,
+    "title": "핵심만 콕 쿠버네티스",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791165920180.jpg",
+    "author": "유홍근(커피고래)",
+    "publisher": "비제이퍼블릭",
+    "category": "인프라",
+    "date": "2020-09-18",
+    "detail": "https://product.kyobobook.co.kr/detail/S000001842159",
+    "state": "대여 가능",
+    "memberID": ""
+  },
+  {
+    "id": 3,
+    "title": "김정은은 군필 여대생인가?",
+    "image": "https://placekitten.com/700/700",
+    "author": "김관식",
+    "publisher": "경기대",
+    "category": "",
+    "date": "2023-11-25",
+    "detail": "",
+    "state": "대여 가능",
+    "memberID": ""
+  },
+  {
+    "id": 4,
+    "title": "이것이 자바다",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791169210027.jpg",
+    "author": "신용권, 임경균",
+    "publisher": "한빛미디어",
+    "category": "개발",
+    "date": "",
+    "detail": "https://product.kyobobook.co.kr/detail/S000061695652",
+    "state": "대여 가능",
+    "memberID": ""
+  },
+  {
+    "id": 5,
+    "title": "면접을 위한 CS 전공지식 노트",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791165219529.jpg",
+    "author": "주홍철",
+    "publisher": "길벗",
+    "category": "개발",
+    "date": "",
+    "detail": "https://product.kyobobook.co.kr/detail/S000001834833",
+    "state": "대여 중",
+    "memberID": ""
+  },
+  {
+    "id": 6,
+    "title": "리액트를 다루는 기술",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791160508796.jpg",
+    "author": "김민준",
+    "publisher": "길벗",
+    "category": "개발",
+    "date": "2019-08-31",
+    "detail": "https://product.kyobobook.co.kr/detail/S000001792882",
+    "state": "대여 중",
+    "memberID": ""
+  },
+  {
+    "id": 7,
+    "title": "이것이 자바다",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791169210027.jpg",
+    "author": "신용권, 임경균",
+    "publisher": "한빛미디어",
+    "category": "개발",
+    "date": "",
+    "detail": "https://product.kyobobook.co.kr/detail/S000061695652",
+    "state": "대여 가능",
+    "memberID": ""
+  },
+  {
+    "id": 8,
+    "title": "핵심만 콕 쿠버네티스",
+    "image": "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791165920180.jpg",
+    "author": "유홍근(커피고래)",
+    "publisher": "비제이퍼블릭",
+    "category": "인프라",
+    "date": "2020-09-18",
+    "detail": "https://product.kyobobook.co.kr/detail/S000001842159",
+    "state": "대여 가능",
+    "memberID": ""
+  }
+]

--- a/apps/member/src/pages/LibraryDetailPage/LibraryDetailPage.tsx
+++ b/apps/member/src/pages/LibraryDetailPage/LibraryDetailPage.tsx
@@ -1,0 +1,38 @@
+import { useParams } from 'react-router-dom';
+import bookCollection from '@mocks/data/bookCollection.json';
+import Content from '@components/common/Content/Content';
+import Header from '@components/common/Header/Header';
+import ErrorPage from '@pages/ErrorPage/ErrorPage';
+import BookDetailSection from '@components/library/BookDetailSection/BookDetailSection';
+
+interface BookData {
+  id: number;
+  title: string;
+  image: string;
+  author: string;
+  publisher: string;
+  category: string;
+  date: string;
+  detail: string;
+  state: string;
+}
+
+const LibraryDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const data: BookData | undefined = bookCollection.find(
+    (book) => book.id === Number(id),
+  );
+
+  if (data === undefined) {
+    return <ErrorPage />;
+  }
+  return (
+    <Content>
+      <Header title={['도서관', data.title]} />
+      <BookDetailSection data={data} />
+      <Header title="대출내역" />
+    </Content>
+  );
+};
+
+export default LibraryDetailPage;

--- a/apps/member/src/pages/LibraryPage/LibraryPage.tsx
+++ b/apps/member/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,0 +1,16 @@
+import Content from '@components/common/Content/Content';
+import Header from '@components/common/Header/Header';
+import LibraryNewBookSection from '@components/library/LibraryNewBookSection/LibraryNewBookSection';
+import LibraryOwnBookSection from '@components/library/LibraryOwnBookSection/LibraryOwnBookSection';
+
+const LibraryPage = () => {
+  return (
+    <Content>
+      <Header title="도서관" />
+      <LibraryNewBookSection />
+      <LibraryOwnBookSection />
+    </Content>
+  );
+};
+
+export default LibraryPage;

--- a/apps/member/src/router/AppRouter.tsx
+++ b/apps/member/src/router/AppRouter.tsx
@@ -11,6 +11,8 @@ import CommunityWritePage from '@pages/CommunityWritePage/CommunityWritePage';
 import MyPage from '@pages/MyPage/MyPage';
 import CalendarPage from '@pages/CalendarPage/CalendarPage';
 import SupportPage from '@pages/SupportPage/SupportPage';
+import LibraryPage from '@pages/LibraryPage/LibraryPage';
+import LibraryDetailPage from '@pages/LibraryDetailPage/LibraryDetailPage';
 
 const AppRouter = () => {
   const router = createBrowserRouter([
@@ -27,6 +29,8 @@ const AppRouter = () => {
         { path: PATH.MY, element: <MyPage /> },
         { path: PATH.CALENDER, element: <CalendarPage /> },
         { path: PATH.SUPPORT, element: <SupportPage /> },
+        { path: PATH.LIBRARY, element: <LibraryPage /> },
+        { path: PATH.LIBRARY_DETAIL, element: <LibraryDetailPage /> },
       ],
     },
   ]);


### PR DESCRIPTION
## Summary

> LibraryPage 마이그레이션

기존에 작성한 LibraryPage의 자바스크립트 코드를 타입스크립트로 마이그레이션 합니다

## Tasks

- 소유하고 있는 도서를 조회하고 대여할 수 있는 페이지를 타입스크립트로 마이그레이션

## Screenshot

<img width="1792" alt="스크린샷 2024-01-24 오후 4 24 43" src="https://github.com/KGU-C-Lab/clab.page/assets/128335727/a297319c-19f5-4738-bb66-2f20e8e3c6c3">
<img width="1792" alt="스크린샷 2024-01-24 오후 4 24 45" src="https://github.com/KGU-C-Lab/clab.page/assets/128335727/11175e7b-0bd8-4b4e-94f3-c773875b650d">
<img width="1792" alt="스크린샷 2024-01-24 오후 4 24 49" src="https://github.com/KGU-C-Lab/clab.page/assets/128335727/74827a07-bc5e-4250-9709-5ec8eebe8564">
<img width="1792" alt="스크린샷 2024-01-24 오후 4 24 59" src="https://github.com/KGU-C-Lab/clab.page/assets/128335727/4fcd568f-a375-467f-8c32-902464743169">
