### PR TITLE
feat: 일정 API 연동

### DIFF
--- a/apps/member/src/api/schedule.ts
+++ b/apps/member/src/api/schedule.ts
@@ -1,8 +1,8 @@
-import { PaginationType } from '@type/api';
+import { BaseResponse, PaginationType } from '@type/api';
 import { server } from './server';
 import { END_POINT } from '@constants/api';
 import { createSchedulePagination } from '@utils/api';
-import type { ScheduleItem } from '@type/schedule';
+import type { ScheduleItem, ScheduleRegisterItem } from '@type/schedule';
 
 // 일정 조회
 export const getSchedule = async (
@@ -19,6 +19,17 @@ export const getSchedule = async (
       page,
       size,
     ),
+  });
+  return data;
+};
+
+// 일정 추가
+export const postSchedule = async (requestBody: ScheduleRegisterItem) => {
+  console.log(requestBody);
+  const jsonRequestBody = JSON.stringify(requestBody);
+  const { data } = await server.post<string, BaseResponse<number>>({
+    url: END_POINT.MAIN_SCHEDULE,
+    body: jsonRequestBody,
   });
   return data;
 };

--- a/apps/member/src/components/calendar/AddSchedule/AddSchedule.tsx
+++ b/apps/member/src/components/calendar/AddSchedule/AddSchedule.tsx
@@ -1,0 +1,82 @@
+import { Button, Input } from '@clab/design-system';
+import Section from '@components/common/Section/Section';
+import { ChangeEvent, useState } from 'react';
+import type { ScheduleRegisterItem } from '@type/schedule';
+import dayjs from 'dayjs';
+import { postSchedule } from '@api/schedule';
+
+const AddSchedule = () => {
+  const [inputs, setInputs] = useState<ScheduleRegisterItem>({
+    title: '',
+    detail: '',
+    startDateTime: '',
+    endDateTime: '',
+  });
+  const { title, detail, startDateTime, endDateTime } = inputs;
+
+  const onChangeInputs = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputs((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const onClickAdd = () => {
+    if (!title || !detail || !startDateTime || !endDateTime) {
+      alert('필수 입력 사항을 모두 입력해주세요.');
+    } else {
+      const requestBody: ScheduleRegisterItem = {
+        scheduleType: 'ALL',
+        title: title,
+        detail: detail,
+        startDateTime: dayjs(startDateTime).toISOString(),
+        endDateTime: dayjs(endDateTime).toISOString(),
+        activityGroupId: 0,
+      };
+      postSchedule(requestBody);
+      alert('추가되었습니다.');
+    }
+  };
+
+  return (
+    <Section className="space-y-4">
+      <Input
+        label="일정명"
+        id="title"
+        name="title"
+        placeholder="일정명을 입력해주세요."
+        value={title}
+        onChange={onChangeInputs}
+      />
+      <Input
+        label="설명"
+        id="detail"
+        name="detail"
+        placeholder="설명을 입력해주세요."
+        value={detail}
+        onChange={onChangeInputs}
+      />{' '}
+      <Input
+        label="시작일"
+        type="date"
+        id="startDateTime"
+        name="startDateTime"
+        value={startDateTime}
+        onChange={onChangeInputs}
+      />{' '}
+      <Input
+        label="마감일"
+        type="date"
+        id="endDateTime"
+        name="endDateTime"
+        value={endDateTime}
+        onChange={onChangeInputs}
+      />
+      <Button onClick={onClickAdd} size="sm">
+        일정추가
+      </Button>
+    </Section>
+  );
+};
+
+export default AddSchedule;

--- a/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
+++ b/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import schedule from '@mocks/data/schedule.json';
+import { useMainSchedule } from '@hooks/queries/useSchedule';
 
 interface CalendarScheduleProps {
   date: dayjs.Dayjs;
@@ -7,31 +7,44 @@ interface CalendarScheduleProps {
 
 const CalendarSchedule = ({ date }: CalendarScheduleProps) => {
   const checkedDate = dayjs(date).startOf('day');
+  const { data: mySchedule } = useMainSchedule(
+    String(checkedDate.startOf('day').format('YYYY-MM-DDTHH:mm:ss.SSS')),
+    undefined,
+    0,
+    20,
+  );
 
   const onClickSchedule = (detail: string, start: string, end: string) => {
     alert(`${detail}\n${start} ~ ${end}`);
   };
 
-  return schedule.map(({ title, detail, startDate, endDate }, index) => {
-    const start = dayjs(startDate).startOf('day');
-    const end = dayjs(endDate).endOf('day');
+  if (!mySchedule) {
+    return null;
+  }
 
-    if (
-      checkedDate.isSame(start) ||
-      checkedDate.isSame(end) ||
-      (checkedDate.isAfter(start) && checkedDate.isBefore(end))
-    ) {
-      return (
-        <p
-          key={index}
-          className="cursor-pointer text-xs border-l-2 border-red-500 hover:bg-gray-50"
-          onClick={() => onClickSchedule(detail, startDate, endDate)}
-        >
-          {title}
-        </p>
-      );
-    }
-  });
+  return mySchedule.items
+    ? mySchedule.items.map(({ title, detail, startDate, endDate }, index) => {
+        const start = dayjs(startDate).startOf('day');
+        const end = dayjs(endDate).endOf('day');
+
+        if (
+          checkedDate.isSame(start) ||
+          checkedDate.isSame(end) ||
+          (checkedDate.isAfter(start) && checkedDate.isBefore(end))
+        ) {
+          return (
+            <p
+              key={index}
+              className="cursor-pointer text-xs border-l-2 border-red-500 hover:bg-gray-50"
+              onClick={() => onClickSchedule(detail, startDate, endDate)}
+            >
+              {title}
+            </p>
+          );
+        }
+        return null;
+      })
+    : null;
 };
 
 export default CalendarSchedule;

--- a/apps/member/src/components/calendar/CalendarSection/CalendarSection.tsx
+++ b/apps/member/src/components/calendar/CalendarSection/CalendarSection.tsx
@@ -1,6 +1,6 @@
 import Section from '@components/common/Section/Section';
 import dayjs from 'dayjs';
-import { useState } from 'react';
+import { startTransition, useState } from 'react';
 import Calendar from '../Calendar/Calendar';
 
 const now = dayjs();
@@ -11,24 +11,30 @@ const CalendarSection = () => {
   const [month, setMonth] = useState(now.get('month') + 1);
 
   const onClickPrev = () => {
-    const prevMonth = month - 1 <= 0 ? 12 : month - 1;
-    const prevYear = month - 1 <= 0 ? year - 1 : year;
+    startTransition(() => {
+      const prevMonth = month - 1 <= 0 ? 12 : month - 1;
+      const prevYear = month - 1 <= 0 ? year - 1 : year;
 
-    setYear(prevYear);
-    setMonth(prevMonth);
+      setYear(prevYear);
+      setMonth(prevMonth);
+    });
   };
 
   const onClickNext = () => {
-    const nextMonth = month + 1 > 12 ? 1 : month + 1;
-    const nextYear = month + 1 > 12 ? year + 1 : year;
+    startTransition(() => {
+      const nextMonth = month + 1 > 12 ? 1 : month + 1;
+      const nextYear = month + 1 > 12 ? year + 1 : year;
 
-    setYear(nextYear);
-    setMonth(nextMonth);
+      setYear(nextYear);
+      setMonth(nextMonth);
+    });
   };
 
   const onClickToday = () => {
-    setYear(now.get('year'));
-    setMonth(now.get('month') + 1);
+    startTransition(() => {
+      setYear(now.get('year'));
+      setMonth(now.get('month') + 1);
+    });
   };
 
   return (

--- a/apps/member/src/pages/CalendarPage/CalendarPage.tsx
+++ b/apps/member/src/pages/CalendarPage/CalendarPage.tsx
@@ -2,13 +2,22 @@ import CalendarSection from '@components/calendar/CalendarSection/CalendarSectio
 import Content from '@components/common/Content/Content';
 import Header from '@components/common/Header/Header';
 import { Button } from '@clab/design-system';
+import AddSchedule from '@components/calendar/AddSchedule/AddSchedule';
+import { useState } from 'react';
 
 const CalendarPage = () => {
+  const [isAddScheduleOpen, setIsAddScheduleOpen] = useState(false);
+  const onClickAddSchedule = () => {
+    setIsAddScheduleOpen((prev) => !prev);
+  };
   return (
     <Content>
       <Header title="일정">
-        <Button size="sm">일정추가</Button>
+        <Button onClick={onClickAddSchedule} size="sm">
+          일정추가
+        </Button>
       </Header>
+      {isAddScheduleOpen && <AddSchedule />}
       <CalendarSection />
     </Content>
   );

--- a/apps/member/src/types/schedule.ts
+++ b/apps/member/src/types/schedule.ts
@@ -7,3 +7,12 @@ export interface ScheduleItem {
   endDate: string;
   to?: string;
 }
+
+export interface ScheduleRegisterItem {
+  scheduleType?: string;
+  title: string;
+  detail: string;
+  startDateTime: string;
+  endDateTime: string;
+  activityGroupId?: number;
+}


### PR DESCRIPTION
## Summary

> 일정 관련 API 연동

캘린더 페이지 내의 일정을 표시할 수 있도록 API를 연동합니다.

## Tasks

- 일정을 조회하는 API를 연결합니다.
- 일정을 추가하는 API를 연동합니다.

## ETC

일정 추가 API가 제대로 동작하지 않고 400 error가 발생합니다. 해결 방안을 찾으려 노력했지만 발견하지 못하여 추후 발견 시에 수정하도록 하겠습니다. 😢

## Screenshot

![스크린샷 2024-02-08 오후 9 53 49](https://github.com/KGU-C-Lab/clab.page/assets/128335727/f12ab11c-4572-464a-b014-ab14cc1a5f1a)
![스크린샷 2024-02-08 오후 9 53 53](https://github.com/KGU-C-Lab/clab.page/assets/128335727/58dab218-c43f-4a45-bea2-e2df5c8f93e5)

