### PR TITLE
프로필 수정 시 비밀번호 초기화 개선

### DIFF
--- a/apps/member/src/api/member.ts
+++ b/apps/member/src/api/member.ts
@@ -9,6 +9,7 @@ interface PatchUserInfoArgs {
   body: ProfileData;
   multipartFile: FormData | null;
 }
+
 // 내 정보
 export const getMyProfile = async () => {
   const { data } = await server.get<BaseResponse<ProfileData>>({
@@ -24,21 +25,14 @@ export const patchUserInfo = async ({
   body,
   multipartFile,
 }: PatchUserInfoArgs) => {
-  let userInfoData;
   if (multipartFile) {
     const data = await postUploadedFileProfileImage(multipartFile);
-
-    userInfoData = {
-      ...body,
-      imageUrl: data.fileUrl,
-    };
-  } else {
-    userInfoData = body;
+    body['imageUrl'] = data.fileUrl;
   }
 
   const { data } = await server.patch<ProfileData, BaseResponse<string>>({
     url: END_POINT.MY_INFO_EDIT(id),
-    body: userInfoData,
+    body,
   });
 
   return data;

--- a/apps/member/src/constants/message.ts
+++ b/apps/member/src/constants/message.ts
@@ -1,5 +1,5 @@
 export const ERROR_MESSAGE = {
-  default: '⚠️ 뭔가 잘못됐어요..',
+  DEFAULT: '오류가 발생했어요. 잠시후에 다시 시도해주세요.',
 } as const;
 
 export const COMMUNITY_MESSAGE = {

--- a/apps/member/src/hooks/common/useModal.ts
+++ b/apps/member/src/hooks/common/useModal.ts
@@ -1,6 +1,8 @@
 import { useSetModalStore } from '@store/modal';
+import { now } from '@utils/date';
 
 interface OpenModalProps {
+  key?: string;
   title?: string;
   content: React.ReactNode;
   accept?: {
@@ -15,14 +17,18 @@ interface OpenModalProps {
 
 const useModal = () => {
   const setModal = useSetModalStore();
-
+  /**
+   * open modal
+   */
   const openModal = ({
+    key = now().toString(),
     title = 'C-Lab PLAY',
     content,
     accept,
     cancel,
   }: OpenModalProps) => {
     setModal({
+      key,
       isOpen: true,
       title,
       content,
@@ -33,12 +39,22 @@ const useModal = () => {
       },
     });
   };
-
+  /**
+   * close modal
+   */
   const closeModal = () => {
     setModal((prev) => ({ ...prev, isOpen: false }));
   };
+  /**
+   * update modal
+   * - when you need to update modal content
+   * - ex) when you need to update modal content after user input
+   */
+  const updateModal = () => {
+    setModal((prev) => ({ ...prev, key: now().toString() }));
+  };
 
-  return { openModal, closeModal };
+  return { openModal, closeModal, updateModal };
 };
 
 export default useModal;

--- a/apps/member/src/hooks/queries/useUserInfoMutation.ts
+++ b/apps/member/src/hooks/queries/useUserInfoMutation.ts
@@ -2,7 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchUserInfo } from '@api/member';
 import { QUERY_KEY } from '@constants/key';
 import useToast from '@hooks/common/useToast';
+import { ERROR_MESSAGE } from '@constants/message';
 
+/**
+ * 회원의 정보를 수정합니다.
+ */
 export const useUserInfoMutation = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -12,6 +16,9 @@ export const useUserInfoMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.MY_PROFILE] });
       toast({ state: 'success', message: '프로필이 수정되었습니다.' });
+    },
+    onError: () => {
+      toast({ state: 'error', message: ERROR_MESSAGE.DEFAULT });
     },
   });
 

--- a/apps/member/src/store/modal.ts
+++ b/apps/member/src/store/modal.ts
@@ -7,6 +7,7 @@ import {
 } from 'recoil';
 
 interface ModalState {
+  key: string;
   isOpen: boolean;
   title: string;
   content: React.ReactNode;
@@ -23,6 +24,7 @@ interface ModalState {
 export const modalState = atom<ModalState>({
   key: ATOM_KEY.MODAL,
   default: {
+    key: '',
     isOpen: false,
     title: '',
     content: null,


### PR DESCRIPTION
## Summary

> 프로필 수정 시 비밀번호 초기화 버그를 개선했습니다.

버그 개선과 Modal 변경사항이 포함되어 있습니다.

## Tasks

- 비밀번호 초기화 오류를 개선했습니다.
- `useModal `Hook에 `Key`를 추가했습니다.
- `useUserInfoMutation`에 `onError` 에러 메세지를 추가했습니다.

## ETC

## Screenshot

<img width="675" alt="image" src="https://github.com/KGU-C-Lab/clab.page/assets/39869096/82e0524b-b360-4d0e-835f-97541f7e817a">

