### PR TITLE
[Member] 캘린더 사용자 피드백 개선

### DIFF
--- a/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
+++ b/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import useModal from '@hooks/common/useModal';
-import { formattedDate, now } from '@utils/date';
+import { formattedDatePeriod, now } from '@utils/date';
 import { cn } from '@utils/string';
 import dayjs from 'dayjs';
 
@@ -25,16 +25,10 @@ const CalendarSchedule = ({
   const isBeforeToday = day.isBefore(today, 'day');
 
   const handleScheduleClick = useCallback(
-    (detail: string, start: string, end: string) => {
-      // 시작일과 종료일이 같은 경우, 종료일은 표시하지 않는다.
-      const date =
-        start === end
-          ? `${formattedDate(start)}`
-          : `${formattedDate(start)} ~ ${formattedDate(end)}`;
-
+    (detail: string, startDate: string, endDate: string) => {
       openModal({
         title: '📆 일정',
-        content: `일시: ${date}\n내용: ${detail}`,
+        content: `일시: ${formattedDatePeriod(startDate, endDate)}\n내용: ${detail}`,
       });
     },
     [openModal],

--- a/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
+++ b/apps/member/src/components/calendar/CalendarSchedule/CalendarSchedule.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import useModal from '@hooks/common/useModal';
-import { formattedDate } from '@utils/date';
+import { formattedDate, now } from '@utils/date';
 import { cn } from '@utils/string';
 import dayjs from 'dayjs';
 
@@ -10,6 +10,8 @@ import type { ScheduleItem } from '@type/schedule';
 interface CalendarScheduleProps extends ScheduleItem {
   day: dayjs.Dayjs;
 }
+
+const today = now();
 
 const CalendarSchedule = ({
   day,
@@ -20,6 +22,7 @@ const CalendarSchedule = ({
 }: CalendarScheduleProps) => {
   const { openModal } = useModal();
   const isDateDiff = dayjs(startDate).diff(endDate, 'd');
+  const isBeforeToday = day.isBefore(today, 'day');
 
   const handleScheduleClick = useCallback(
     (detail: string, start: string, end: string) => {
@@ -56,6 +59,7 @@ const CalendarSchedule = ({
           'rounded-r bg-red-100':
             isDateDiff !== 0 && day.isSame(endDate, 'date'),
         },
+        { 'opacity-50': isBeforeToday },
       )}
       onClick={() => handleScheduleClick(detail, startDate, endDate)}
     >

--- a/apps/member/src/components/calendar/CalendarSection/CalendarSection.tsx
+++ b/apps/member/src/components/calendar/CalendarSection/CalendarSection.tsx
@@ -42,10 +42,15 @@ const CalendarSection = () => {
 
   while (day.isBefore(endDay)) {
     const isToday = day.isSame(today, 'day');
+    const isBeforeToday = day.isBefore(today, 'day');
 
     days.push(
       <td key={day.format('DD-MM-YYYY')} className="h-28 border">
-        <div className="flex h-full flex-col items-end space-y-1">
+        <div
+          className={cn('flex h-full flex-col items-end gap-1', {
+            'bg-gray-50 opacity-60': isBeforeToday,
+          })}
+        >
           <p
             className={cn('m-1 size-5 rounded-full text-center text-sm', {
               'bg-red-500 text-white': isToday,

--- a/apps/member/src/components/calendar/CalendarTableSection/CalendarTableSection.tsx
+++ b/apps/member/src/components/calendar/CalendarTableSection/CalendarTableSection.tsx
@@ -4,6 +4,7 @@ import { Table } from '@clab/design-system';
 
 import { Section } from '@components/common/Section';
 
+import { TABLE_HEAD } from '@constants/head';
 import useModal from '@hooks/common/useModal';
 import { useSchedule } from '@hooks/queries';
 import { formattedDate, formattedDatePeriod } from '@utils/date';
@@ -24,7 +25,7 @@ const CalendarTableSection = () => {
 
   return (
     <Section>
-      <Table head={['날짜', '일정명']} className="table-fixed">
+      <Table head={TABLE_HEAD.CALENDAR_TABLE} className="table-fixed">
         {data.items.map(({ id, title, detail, startDate, endDate }) => (
           <Table.Row
             key={id}

--- a/apps/member/src/components/calendar/CalendarTableSection/CalendarTableSection.tsx
+++ b/apps/member/src/components/calendar/CalendarTableSection/CalendarTableSection.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import { Table } from '@clab/design-system';
+
+import { Section } from '@components/common/Section';
+
+import useModal from '@hooks/common/useModal';
+import { useSchedule } from '@hooks/queries';
+import { formattedDate, formattedDatePeriod } from '@utils/date';
+
+const CalendarTableSection = () => {
+  const { openModal } = useModal();
+  const { data } = useSchedule();
+
+  const handleScheduleClick = useCallback(
+    (detail: string, startDate: string, endDate: string) => {
+      openModal({
+        title: '📆 일정',
+        content: `일시: ${formattedDatePeriod(startDate, endDate)}\n내용: ${detail}`,
+      });
+    },
+    [openModal],
+  );
+
+  return (
+    <Section>
+      <Table head={['날짜', '일정명']} className="table-fixed">
+        {data.items.map(({ id, title, detail, startDate, endDate }) => (
+          <Table.Row
+            key={id}
+            onClick={() => handleScheduleClick(detail, startDate, endDate)}
+          >
+            <Table.Cell>{`${formattedDate(startDate)} ~ ${formattedDate(endDate)}`}</Table.Cell>
+            <Table.Cell>{title}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table>
+    </Section>
+  );
+};
+
+export default CalendarTableSection;

--- a/apps/member/src/constants/head.ts
+++ b/apps/member/src/constants/head.ts
@@ -13,6 +13,7 @@ export const TABLE_HEAD = {
     '기능',
   ],
   CALENDAR_SCHEDULE: ['번호', '제목', '시작일', '종료일', '중요도', '기능'],
+  CALENDAR_TABLE: ['날짜', '일정'],
 } as const;
 /**
  * 관리자 페이지에서 기능을 나타내는 상수

--- a/apps/member/src/pages/CalendarPage/CalendarPage.tsx
+++ b/apps/member/src/pages/CalendarPage/CalendarPage.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 
 import CalendarSection from '@components/calendar/CalendarSection/CalendarSection';
 import CalendarStatusSection from '@components/calendar/CalendarStatusSection/CalendarStatusSection';
+import CalendarTableSection from '@components/calendar/CalendarTableSection/CalendarTableSection';
 import Content from '@components/common/Content/Content';
 import Header from '@components/common/Header/Header';
 
@@ -14,6 +15,9 @@ const CalendarPage = () => {
       </Suspense>
       <Suspense>
         <CalendarSection />
+      </Suspense>
+      <Suspense>
+        <CalendarTableSection />
       </Suspense>
     </Content>
   );

--- a/apps/member/src/utils/date.ts
+++ b/apps/member/src/utils/date.ts
@@ -43,6 +43,20 @@ export function formattedDate(date: string | undefined | null): string {
   return dayjs(date).format('YY.MM.DD(dd) HH:mm');
 }
 /**
+ * 주어진 시작일과 종료일을 형식화된 날짜 기간 문자열로 반환합니다.
+ * 시작일과 종료일이 동일한 경우 시작일의 형식화된 날짜를 반환합니다.
+ * 시작일과 종료일이 다른 경우 시작일과 종료일을 형식화된 날짜로 연결한 문자열을 반환합니다.
+ * @param startDate 시작일을 나타내는 문자열
+ * @param endDate 종료일을 나타내는 문자열
+ * @returns 형식화된 날짜 기간 문자열
+ */
+export function formattedDatePeriod(startDate: string, endDate: string) {
+  return startDate === endDate
+    ? formattedDate(startDate)
+    : `${formattedDate(startDate)} ~ ${formattedDate(endDate)}`;
+}
+
+/**
  * 주어진 초를 'mm:ss' 형식으로 포맷합니다.
  *
  * @param {number} seconds - 초 단위의 시간.


### PR DESCRIPTION
## Summary

> 운영진 오픈 베타에서 제안된 캘린더 피드백을 개선합니다.

## Tasks

### 리팩토링(Refactoring):
- **캘린더 지난 날 다른 색으로 표시**: 캘린더에서 지난 날짜들을 다른 색상으로 표시하여, 사용자가 현재 날짜와 지난 날짜를 쉽게 구분할 수 있도록 개선했습니다.
- **`formattedDatePeriod` 함수 추가**: 날짜 범위가 동일 할 경우 하루를 표시하고, 범위가 다를 경우 ~ 로 연결하여 표시하는 함수입니다.

### 새로운 기능(Features):
- **`CalendarTableSection` 추가**: 캘린더 테이블 섹션을 추가하여, 일정을 테이블 형태로 보여주는 기능을 구현했습니다. 

## Screenshot

<img width="916" alt="image" src="https://github.com/KGU-C-Lab/clab.page/assets/39869096/25348ae0-591c-45de-acb2-405e7a57bf25">
