### PR TITLE
fix(auth): fix typo in REDIRECT_WITH_TOKEN function (#131)

### DIFF
--- a/apps/auth/src/utils/service.ts
+++ b/apps/auth/src/utils/service.ts
@@ -25,5 +25,5 @@ export function SERVICE(code: ServiceCode | null) {
  */
 export function REDIRECT_WITH_TOKEN(code: ServiceCode, token: Token) {
   const { url } = SERVICE(code) ?? {};
-  return `${url}/?a=${token.accessToken}}&r=${token.refreshToken}`;
+  return `${url}/?a=${token.accessToken}&r=${token.refreshToken}`;
 }


### PR DESCRIPTION
## Summary

액세스 토큰 파싱 중 `}`가 포함되어 리다이렉션 되는 현상을 개선하였습니다.