### PR TITLE
커뮤니티 UI 개선

### DIFF
--- a/apps/member/src/api/board.ts
+++ b/apps/member/src/api/board.ts
@@ -3,11 +3,11 @@ import { createCommonPagination } from '@utils/api';
 
 import { BaseResponse, ResponsePagination } from '@type/api';
 import type {
+  Board,
   CommunityCategoryType,
   CommunityPostDetailItem,
   CommunityPostItem,
   CommunityWriteItem,
-  IBoard,
 } from '@type/community';
 
 import { server } from './server';
@@ -26,7 +26,7 @@ export interface PatchBoardsParams extends CommunityWriteItem {
  * 내가 작성한 커뮤니티 게시글 조회
  */
 export async function getMyBoards(page: number, size: number) {
-  const { data } = await server.get<ResponsePagination<IBoard>>({
+  const { data } = await server.get<ResponsePagination<Board>>({
     url: createCommonPagination(END_POINT.MY_BOARDS, { page, size }),
   });
 
@@ -36,7 +36,7 @@ export async function getMyBoards(page: number, size: number) {
  * 커뮤니티 게시글 목록 조회
  */
 export async function getBoards(page: number, size: number) {
-  const { data } = await server.get<ResponsePagination<IBoard>>({
+  const { data } = await server.get<ResponsePagination<Board>>({
     url: createCommonPagination(END_POINT.BOARDS, { page, size }),
   });
 

--- a/apps/member/src/components/common/CommentCounter/CommentCounter.tsx
+++ b/apps/member/src/components/common/CommentCounter/CommentCounter.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+
+interface CommentCounterProps extends PropsWithChildren {}
+
+const CommentCounter = ({ children }: CommentCounterProps) => {
+  if (typeof children !== 'number') {
+    return null;
+  }
+
+  return <span className="font-medium text-red-500">{` [${children}]`}</span>;
+};
+
+export default CommentCounter;

--- a/apps/member/src/components/common/Nav/Nav.tsx
+++ b/apps/member/src/components/common/Nav/Nav.tsx
@@ -7,6 +7,7 @@ import { IS_DEVELOPMENT } from '@constants/environment';
 import { PATH } from '@constants/path';
 import useModal from '@hooks/common/useModal';
 import { useMyProfile } from '@hooks/queries';
+import { cn } from '@utils/string';
 
 import Sidebar from '../Sidebar/Sidebar';
 
@@ -28,7 +29,11 @@ const Nav = () => {
   };
 
   return (
-    <nav className="fixed left-0 top-0 z-30 w-full border-b bg-white">
+    <nav
+      className={cn('fixed left-0 top-0 z-30 w-full border-b bg-white', {
+        'border-b-orange-300': IS_DEVELOPMENT,
+      })}
+    >
       <div className="container flex h-14 items-center justify-between bg-white">
         <div className="flex items-center gap-10 lg:gap-20">
           <Link className="flex items-center gap-2 text-xl" to={PATH.MAIN}>

--- a/apps/member/src/components/common/Skeleton/Skeleton.tsx
+++ b/apps/member/src/components/common/Skeleton/Skeleton.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@utils/string';
+
+interface SkeletonProps {
+  size?: string;
+  width?: string;
+  height?: string;
+  className?: string;
+}
+
+const Skeleton = ({ size, width, height, className }: SkeletonProps) => {
+  if (size) {
+    width = size;
+    height = size;
+  }
+
+  return (
+    <div
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+      }}
+      className={cn(
+        'animate-pulse rounded-lg bg-gray-200',
+        { 'w-full': !width, 'h-full': !height },
+        className,
+      )}
+    ></div>
+  );
+};
+
+export default Skeleton;

--- a/apps/member/src/components/common/Skeleton/Skeleton.tsx
+++ b/apps/member/src/components/common/Skeleton/Skeleton.tsx
@@ -5,16 +5,24 @@ interface SkeletonProps {
   width?: string;
   height?: string;
   className?: string;
+  repeat?: number;
 }
 
-const Skeleton = ({ size, width, height, className }: SkeletonProps) => {
+const Skeleton = ({
+  size,
+  width,
+  height,
+  className,
+  repeat = 1,
+}: SkeletonProps) => {
   if (size) {
     width = size;
     height = size;
   }
 
-  return (
+  return Array.from({ length: repeat }).map((_, index) => (
     <div
+      key={index}
       style={{
         width: `${width}px`,
         height: `${height}px`,
@@ -24,8 +32,8 @@ const Skeleton = ({ size, width, height, className }: SkeletonProps) => {
         { 'w-full': !width, 'h-full': !height },
         className,
       )}
-    ></div>
-  );
+    />
+  ));
 };
 
 export default Skeleton;

--- a/apps/member/src/components/community/Board/BoardSkeleton.tsx
+++ b/apps/member/src/components/community/Board/BoardSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Section } from '@components/common/Section';
+import Skeleton from '@components/common/Skeleton/Skeleton';
+
+const BoardSkeleton = () => {
+  return (
+    <Section>
+      <Skeleton width="100" height="24" />
+      <Section.Body className="space-y-2">
+        <Skeleton height="20" />
+        <Skeleton height="20" />
+        <Skeleton height="20" />
+        <Skeleton height="20" />
+        <Skeleton height="20" />
+        <Skeleton height="20" />
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default BoardSkeleton;

--- a/apps/member/src/components/community/Board/BoardSkeleton.tsx
+++ b/apps/member/src/components/community/Board/BoardSkeleton.tsx
@@ -6,12 +6,7 @@ const BoardSkeleton = () => {
     <Section>
       <Skeleton width="100" height="24" />
       <Section.Body className="space-y-2">
-        <Skeleton height="20" />
-        <Skeleton height="20" />
-        <Skeleton height="20" />
-        <Skeleton height="20" />
-        <Skeleton height="20" />
-        <Skeleton height="20" />
+        <Skeleton height="20" repeat={6} />
       </Section.Body>
     </Section>
   );

--- a/apps/member/src/components/community/Board/index.ts
+++ b/apps/member/src/components/community/Board/index.ts
@@ -4,3 +4,4 @@ export { QnABoard } from './Board.tsx';
 export { GraduatedBoard } from './Board.tsx';
 export { NewsBoard } from './Board.tsx';
 export { HireBoard } from './Board.tsx';
+export { default as BoardSkeleton } from './BoardSkeleton.tsx';

--- a/apps/member/src/components/community/BoardCollectCard/BoardCollectCard.tsx
+++ b/apps/member/src/components/community/BoardCollectCard/BoardCollectCard.tsx
@@ -1,0 +1,62 @@
+import { LiaCommentSolid } from 'react-icons/lia';
+import { Link } from 'react-router-dom';
+
+import Image from '@components/common/Image/Image';
+
+import { PATH_FINDER } from '@constants/path';
+import { createImageUrl } from '@utils/api';
+import { getCategoryEmoji } from '@utils/community';
+import { formattedDate } from '@utils/date';
+import { formatMemberName } from '@utils/string';
+
+import type { Board } from '@type/community';
+
+interface BoardCollectCardProps extends Board {}
+
+const BoardCollectCard = ({
+  id,
+  category,
+  title,
+  content,
+  commentCount,
+  writerId,
+  writerName,
+  imageUrl,
+  createdAt,
+}: BoardCollectCardProps) => {
+  return (
+    <Link
+      to={PATH_FINDER.COMMUNITY_POST(category, id)}
+      className="hover:border-clab-main-light flex flex-col items-center gap-2 rounded-lg border p-2 text-sm transition-colors"
+    >
+      <div className="flex w-full items-center gap-4">
+        <div className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-2xl">
+          {getCategoryEmoji(category)}
+        </div>
+        <div className="grid w-full">
+          <p className="truncate font-semibold">{title}</p>
+          <p className="truncate text-gray-500">{content}</p>
+        </div>
+        <div className="flex justify-between gap-2">
+          <p className="flex w-12 items-center gap-1">
+            <LiaCommentSolid />
+            {commentCount}
+          </p>
+          <div className="hidden w-32 md:block">
+            <p>{formatMemberName(writerName, writerId)}</p>
+            <p>{formattedDate(createdAt)}</p>
+          </div>
+        </div>
+      </div>
+      {imageUrl && (
+        <Image
+          src={createImageUrl(imageUrl)}
+          height="h-[200px]"
+          className="rounded-lg object-cover"
+        />
+      )}
+    </Link>
+  );
+};
+
+export default BoardCollectCard;

--- a/apps/member/src/components/community/BoardCollectCard/BoardCollectCardSkeleton.tsx
+++ b/apps/member/src/components/community/BoardCollectCard/BoardCollectCardSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Section } from '@components/common/Section';
+import Skeleton from '@components/common/Skeleton/Skeleton';
+
+const BoardCollectCardSkeleton = () => {
+  return (
+    <Section className="p-2">
+      <div className="flex items-center gap-4">
+        <Skeleton size="48" />
+        <div className="flex grow justify-between gap-4">
+          <Skeleton height="48" />
+          <Skeleton width="100" height="48" />
+        </div>
+      </div>
+      <Section.Body className="mt-2">
+        <Skeleton height="200" />
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default BoardCollectCardSkeleton;

--- a/apps/member/src/components/community/BoardCollectCard/index.ts
+++ b/apps/member/src/components/community/BoardCollectCard/index.ts
@@ -1,0 +1,2 @@
+export { default as BoardCollectCard } from './BoardCollectCard.tsx';
+export { default as BoardCollectCardSkeleton } from './BoardCollectCardSkeleton.tsx';

--- a/apps/member/src/components/community/BoardSection/BoardSection.tsx
+++ b/apps/member/src/components/community/BoardSection/BoardSection.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@clab/design-system';
 
+import CommentCounter from '@components/common/CommentCounter/CommentCounter';
 import ListButton from '@components/common/ListButton/ListButton';
 import MoreButton from '@components/common/MoreButton/MoreButton';
 import Section from '@components/common/Section/Section';
@@ -45,10 +46,11 @@ const BoardSectionItem = ({ title, to, data }: BoardSectionItemProps) => {
         {data.length === 0 ? (
           <p className="text-gray-500">{COMMUNITY_MESSAGE.NO_ARTICLE}</p>
         ) : (
-          data.map(({ id, title, createdAt }) => (
+          data.map(({ id, title, commentCount, createdAt }) => (
             <ListButton key={id} to={createPath(to, id)}>
               <p className="line-clamp-1 w-full pr-4">
                 {toDecodeHTMLEntities(title)}
+                <CommentCounter>{commentCount}</CommentCounter>
               </p>
               <p className="text-clab-main-light">{toYYMMDD(createdAt)}</p>
             </ListButton>

--- a/apps/member/src/components/community/CommunityBoardCollectSection/CommunityBoardCollectSection.tsx
+++ b/apps/member/src/components/community/CommunityBoardCollectSection/CommunityBoardCollectSection.tsx
@@ -1,15 +1,17 @@
-import { LiaCommentSolid } from 'react-icons/lia';
-import { Link } from 'react-router-dom';
-
 import Section from '@components/common/Section/Section';
 
-import { PATH_FINDER } from '@constants/path';
+import { useIntersectionObserver } from '@hooks/common/useIntersectionObserver';
 import { useBoards } from '@hooks/queries';
-import { categoryToTitle } from '@utils/community';
-import { formattedDate } from '@utils/date';
 
+import BoardCollectCard from '../BoardCollectCard/BoardCollectCard';
+
+/**
+ * 커뮤니티 게시글 모아보기
+ * 커뮤니티 게시글을 최신순으로 모아봤어요.
+ */
 const CommunityBoardCollectSection = () => {
-  const { data } = useBoards({ page: 0, size: 6 });
+  const { data, fetchNextPage } = useBoards();
+  const { targetRef } = useIntersectionObserver({ fetchNextPage });
 
   return (
     <Section>
@@ -17,46 +19,12 @@ const CommunityBoardCollectSection = () => {
         title="모아보기"
         description="커뮤니티 게시글을 최신순으로 모아봤어요"
       />
-      <Section.Body className="flex flex-col gap-4">
-        {data.items.map(
-          ({
-            id,
-            writerId,
-            writerName,
-            title,
-            category,
-            content,
-            commentCount,
-            createdAt,
-          }) => (
-            <Link
-              key={id}
-              to={PATH_FINDER.COMMUNITY_POST(category, id)}
-              className="hover:border-clab-main-light flex items-center gap-4 text-nowrap rounded-lg border p-2 text-sm transition-colors"
-            >
-              <p className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-gray-100 font-semibold">
-                {categoryToTitle(category)}
-              </p>
-              <div className="grid w-full">
-                <p className="truncate font-semibold">{title}</p>
-                <p className="truncate text-gray-500 ">{content}</p>
-              </div>
-              <div className="flex justify-between gap-2">
-                <p className="flex w-12 items-center gap-1">
-                  <LiaCommentSolid />
-                  {commentCount}
-                </p>
-                <div className="w-32">
-                  <p>
-                    {writerName} {writerId && `(${writerId})`}
-                  </p>
-                  <p>{formattedDate(createdAt)}</p>
-                </div>
-              </div>
-            </Link>
-          ),
-        )}
+      <Section.Body className="space-y-4">
+        {data.map(({ id, ...props }) => (
+          <BoardCollectCard key={`board-collect-${id}`} id={id} {...props} />
+        ))}
       </Section.Body>
+      <div ref={targetRef}></div>
     </Section>
   );
 };

--- a/apps/member/src/components/community/CommunityBoardCollectSection/CommunityBoardCollectSectionSkeleton.tsx
+++ b/apps/member/src/components/community/CommunityBoardCollectSection/CommunityBoardCollectSectionSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Section } from '@components/common/Section';
+
+import { BoardCollectCardSkeleton } from '../BoardCollectCard';
+
+const CommunityBoardCollectSectionSkeleton = () => {
+  return (
+    <Section>
+      <Section.Header
+        title="모아보기"
+        description="커뮤니티 게시글을 최신순으로 모아봤어요"
+      />
+      <Section.Body>
+        <BoardCollectCardSkeleton />
+        <BoardCollectCardSkeleton />
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default CommunityBoardCollectSectionSkeleton;

--- a/apps/member/src/components/community/CommunityBoardCollectSection/index.ts
+++ b/apps/member/src/components/community/CommunityBoardCollectSection/index.ts
@@ -1,1 +1,2 @@
 export { default as CommunityBoardCollectSection } from './CommunityBoardCollectSection.tsx';
+export { default as CommunityBoardCollectSectionSkeleton } from './CommunityBoardCollectSectionSkeleton.tsx';

--- a/apps/member/src/components/community/CommunityPostsSection/CommunityPostsSection.tsx
+++ b/apps/member/src/components/community/CommunityPostsSection/CommunityPostsSection.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Table } from '@clab/design-system';
 
+import CommentCounter from '@components/common/CommentCounter/CommentCounter';
 import Pagination from '@components/common/Pagination/Pagination';
 import { Section } from '@components/common/Section';
 
@@ -53,28 +54,31 @@ const CommunityPostsSection = ({
               </Table.Cell>
             </Table.Row>
           ) : (
-            data.items.map(({ id, title, writerName, createdAt }, index) => (
-              <Table.Row
-                key={id}
-                className={cn('text-nowrap text-center', {
-                  'bg-gray-50 font-semibold': id === currentId,
-                })}
-                onClick={() => handleBoardClick(id)}
-              >
-                <Table.Cell className="w-1/12">
-                  {data.totalItems - (index + page * size)}
-                </Table.Cell>
-                <Table.Cell className="w-7/12 truncate text-left">
-                  {toDecodeHTMLEntities(title)}
-                </Table.Cell>
-                <Table.Cell className="w-3/12">
-                  {writerName || SERVICE_NAME}
-                </Table.Cell>
-                <Table.Cell className="w-1/12">
-                  {toYYMMDD(createdAt)}
-                </Table.Cell>
-              </Table.Row>
-            ))
+            data.items.map(
+              ({ id, title, commentCount, writerName, createdAt }, index) => (
+                <Table.Row
+                  key={id}
+                  className={cn('text-nowrap text-center', {
+                    'bg-gray-50 font-semibold': id === currentId,
+                  })}
+                  onClick={() => handleBoardClick(id)}
+                >
+                  <Table.Cell className="w-1/12">
+                    {data.totalItems - (index + page * size)}
+                  </Table.Cell>
+                  <Table.Cell className="w-7/12 truncate text-left">
+                    {toDecodeHTMLEntities(title)}
+                    <CommentCounter>{commentCount}</CommentCounter>
+                  </Table.Cell>
+                  <Table.Cell className="w-3/12">
+                    {writerName || SERVICE_NAME}
+                  </Table.Cell>
+                  <Table.Cell className="w-1/12">
+                    {toYYMMDD(createdAt)}
+                  </Table.Cell>
+                </Table.Row>
+              ),
+            )
           )}
         </Table>
         <Pagination

--- a/apps/member/src/components/manage/ManageAlertSection/ManagerAlertSection.tsx
+++ b/apps/member/src/components/manage/ManageAlertSection/ManagerAlertSection.tsx
@@ -14,7 +14,7 @@ import { PATH_FINDER } from '@constants/path';
 import useModal from '@hooks/common/useModal';
 import { usePagination } from '@hooks/common/usePagination';
 import { useBoardDeleteMutation, useCategoryBoards } from '@hooks/queries';
-import { categoryToTitle } from '@utils/community';
+import { getCategoryTitle } from '@utils/community';
 import { toYYMMDD } from '@utils/date';
 import { toDecodeHTMLEntities } from '@utils/string';
 
@@ -35,7 +35,7 @@ const ManagerAlertSection = ({ category }: ManagerAlertSectionProps) => {
   const [mode, setMode] = useState<ModeState>('view');
   const { page, size, handlePageChange } = usePagination();
 
-  const title = categoryToTitle(category);
+  const title = getCategoryTitle(category);
 
   const handleTableRowClick = (id: number) => {
     navigate(PATH_FINDER.COMMUNITY_POST(category, id));

--- a/apps/member/src/components/my/MyHistorySection/MyHistorySection.tsx
+++ b/apps/member/src/components/my/MyHistorySection/MyHistorySection.tsx
@@ -10,13 +10,13 @@ import { toYYMMDD } from '@utils/date';
 
 import type { BookLoanRecordConditionType } from '@type/book';
 import { CommentItem } from '@type/comment';
-import type { IBoard } from '@type/community';
+import type { Board } from '@type/community';
 import type { NotificationItem } from '@type/notification';
 
 interface MyHistorySectionProps {
   title: string;
   data: Array<
-    NotificationItem | IBoard | CommentItem | BookLoanRecordConditionType
+    NotificationItem | Board | CommentItem | BookLoanRecordConditionType
   >;
 }
 
@@ -97,7 +97,7 @@ const MyHistorySection = ({ title, data }: MyHistorySectionProps) => {
              * 나의 게시글
              */
             if ('title' in item) {
-              const { id, category, title, createdAt } = item as IBoard;
+              const { id, category, title, createdAt } = item as Board;
               return (
                 <ListButton
                   key={createdAt}

--- a/apps/member/src/constants/key.ts
+++ b/apps/member/src/constants/key.ts
@@ -13,6 +13,7 @@ export const QUERY_KEY = {
   MY_BOOK: 'MyBook',
   MEMBERS: 'Members',
   BOARDS: 'Boards',
+  BOARDS_COLLECTION: 'BoardsCollection',
   ORGANIZATION: 'Organization',
   BOOK: 'Book',
   BOOK_DETAIL: 'BookDetail',

--- a/apps/member/src/hooks/common/useIntersectionObserver.ts
+++ b/apps/member/src/hooks/common/useIntersectionObserver.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseIntersectionObserver {
+  fetchNextPage: () => void;
+}
+
+export function useIntersectionObserver({
+  fetchNextPage,
+}: UseIntersectionObserver) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (target.isIntersecting) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage],
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 0.5,
+    });
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [handleObserver]);
+
+  return { targetRef } as const;
+}

--- a/apps/member/src/hooks/queries/board/useBoards.ts
+++ b/apps/member/src/hooks/queries/board/useBoards.ts
@@ -1,17 +1,36 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import {
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 
 import { getBoards } from '@api/board';
 import { QUERY_KEY } from '@constants/key';
 
-import type { WithPaginationParams } from '@type/api';
+import { WithPaginationParams } from '@type/api';
 
 /**
  * 커뮤니티 게시글 목록을 조회합니다.
- * 카테고리별로 조회하려면 useCategoryBoards를 사용하세요리
+ * 무한 스크롤을 지원합니다.
+ * 카테고리별로 조회하려면 `useCategoryBoards`를 사용하세요.
  */
-export const useBoards = ({ page = 0, size = 20 }: WithPaginationParams) => {
-  return useSuspenseQuery({
-    queryKey: [QUERY_KEY.BOARDS, { page, size }],
-    queryFn: () => getBoards(page, size),
+export const useBoards = ({ size = 6 }: WithPaginationParams = {}) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    return () => {
+      queryClient.removeQueries({ queryKey: [QUERY_KEY.BOARDS_COLLECTION] });
+    };
+  }, [queryClient]);
+
+  return useSuspenseInfiniteQuery({
+    initialPageParam: 0,
+    queryKey: [QUERY_KEY.BOARDS_COLLECTION],
+    queryFn: ({ pageParam }) => getBoards(pageParam, size),
+    select: (data) => data.pages.flatMap((page) => page.items),
+    getNextPageParam: (lastPage) => {
+      return lastPage.hasNext ? lastPage.currentPage + 1 : null;
+    },
   });
 };

--- a/apps/member/src/pages/CommunityDetailPage/CommunityDetailPage.tsx
+++ b/apps/member/src/pages/CommunityDetailPage/CommunityDetailPage.tsx
@@ -8,7 +8,7 @@ import CommunityWriteButton from '@components/community/CommunityWriteButton/Com
 
 import { ERROR_MESSAGE } from '@constants/message';
 import { PATH, PATH_NAME } from '@constants/path';
-import { categoryToTitle, isCommunityCategoryType } from '@utils/community';
+import { getCategoryTitle, isCommunityCategoryType } from '@utils/community';
 
 import type { CommunityCategoryType } from '@type/community';
 
@@ -22,7 +22,7 @@ const CommunityDetailPage = () => {
   return (
     <Content>
       <Header
-        title={[PATH_NAME.COMMUNITY, categoryToTitle(type)]}
+        title={[PATH_NAME.COMMUNITY, getCategoryTitle(type)]}
         path={[PATH.COMMUNITY]}
       >
         <CommunityWriteButton />

--- a/apps/member/src/pages/CommunityPage/CommunityPage.tsx
+++ b/apps/member/src/pages/CommunityPage/CommunityPage.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import Content from '@components/common/Content/Content';
 import Header from '@components/common/Header/Header';
 import {
+  BoardSkeleton,
   FreeBoard,
   GraduatedBoard,
   HireBoard,
@@ -11,7 +12,10 @@ import {
   QnABoard,
 } from '@components/community/Board';
 import { BoardSection } from '@components/community/BoardSection';
-import { CommunityBoardCollectSection } from '@components/community/CommunityBoardCollectSection';
+import {
+  CommunityBoardCollectSection,
+  CommunityBoardCollectSectionSkeleton,
+} from '@components/community/CommunityBoardCollectSection';
 import CommunityWriteButton from '@components/community/CommunityWriteButton/CommunityWriteButton';
 
 import { PATH_NAME } from '@constants/path';
@@ -23,26 +27,26 @@ const CommunityPage = () => {
         <CommunityWriteButton />
       </Header>
       <BoardSection>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <NoticeBoard />
         </Suspense>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <FreeBoard />
         </Suspense>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <QnABoard />
         </Suspense>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <GraduatedBoard />
         </Suspense>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <NewsBoard />
         </Suspense>
-        <Suspense>
+        <Suspense fallback={<BoardSkeleton />}>
           <HireBoard />
         </Suspense>
       </BoardSection>
-      <Suspense>
+      <Suspense fallback={<CommunityBoardCollectSectionSkeleton />}>
         <CommunityBoardCollectSection />
       </Suspense>
     </Content>

--- a/apps/member/src/pages/CommunityPostPage/CommunityPostPage.tsx
+++ b/apps/member/src/pages/CommunityPostPage/CommunityPostPage.tsx
@@ -14,7 +14,7 @@ import PostCommentSection from '@components/community/PostCommentSection/PostCom
 import { API_ERROR_MESSAGE, ERROR_MESSAGE } from '@constants/message';
 import { PATH, PATH_FINDER, PATH_NAME } from '@constants/path';
 import { usePosts } from '@hooks/queries/usePosts';
-import { categoryToTitle, isCommunityCategoryType } from '@utils/community';
+import { getCategoryTitle, isCommunityCategoryType } from '@utils/community';
 
 import type { CommunityCategoryType } from '@type/community';
 
@@ -48,7 +48,7 @@ const CommunityPostPage = () => {
   return (
     <Content>
       <Header
-        title={[PATH_NAME.COMMUNITY, categoryToTitle(type)]}
+        title={[PATH_NAME.COMMUNITY, getCategoryTitle(type)]}
         path={[PATH.COMMUNITY, PATH_FINDER.COMMUNITY_DETAIL(type)]}
       >
         {isBoardPost && <CommunityWriteButton />}

--- a/apps/member/src/types/community.ts
+++ b/apps/member/src/types/community.ts
@@ -34,7 +34,7 @@ export type EmploymentType =
   | 'ASSISTANT'
   | 'PART_TIME';
 
-export interface IBoard {
+export interface Board {
   id: number;
   category: CommunityCategoryType;
   title: string;

--- a/apps/member/src/types/community.ts
+++ b/apps/member/src/types/community.ts
@@ -42,12 +42,14 @@ export interface Board {
   content: string;
   commentCount: number;
   writerName: string;
+  imageUrl: string | null;
   createdAt: string;
 }
 
 export interface CommunityPostItem {
   id: number;
   title: string;
+  commentCount: number;
   writerId: string | null; // 익명일 경우 null
   writerName: string;
   createdAt: string;

--- a/apps/member/src/utils/community.ts
+++ b/apps/member/src/utils/community.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   CommunityCategoryKorType,
   CommunityCategoryType,
@@ -13,6 +12,19 @@ const COMMUNITY_CATEGORY: CommunityCategoryType[] = [
   'hire',
   'organization',
 ] as const;
+
+const CATEGORY_MAP: Record<
+  CommunityCategoryType,
+  { title: CommunityCategoryKorType; emoji: string }
+> = {
+  notice: { title: '공지사항', emoji: '📢' },
+  free: { title: '자유', emoji: '📝' },
+  qna: { title: 'QnA', emoji: '🤔' },
+  graduated: { title: '졸업생', emoji: '🎓' },
+  news: { title: 'IT 뉴스', emoji: '📰' },
+  hire: { title: '채용 정보', emoji: '👔' },
+  organization: { title: '소식', emoji: '🎉' },
+};
 /**
  * 주어진 커뮤니티 카테고리에 해당하는 한국어 제목을 반환합니다.
  *
@@ -20,53 +32,26 @@ const COMMUNITY_CATEGORY: CommunityCategoryType[] = [
  * @returns {CommunityCategoryKorType} 커뮤니티 카테고리에 해당하는 한국어 제목
  * @throws {Error} 유효하지 않은 카테고리일 경우 에러 발생
  */
-export function categoryToTitle(
+export function getCategoryTitle(
   category: CommunityCategoryType,
 ): CommunityCategoryKorType {
-  const categoryMap: Record<CommunityCategoryType, CommunityCategoryKorType> = {
-    notice: '공지사항',
-    free: '자유',
-    qna: 'QnA',
-    graduated: '졸업생',
-    news: 'IT 뉴스',
-    hire: '채용 정보',
-    organization: '소식',
-  };
-
-  if (category in categoryMap) {
-    return categoryMap[category];
+  if (category in CATEGORY_MAP) {
+    return CATEGORY_MAP[category].title;
   }
-
-  throw new Error(`Invalid category: ${category}`);
+  throw new Error(`Invalid category title: ${category}`);
 }
 /**
- * 주어진 한국어 제목에 해당하는 커뮤니티 카테고리를 반환합니다.
+ * 주어진 커뮤니티 카테고리에 해당하는 이모지를 반환합니다.
  *
- * @param {CommunityCategoryKorType} title - 커뮤니티 카테고리 한국어 제목
- * @returns {CommunityCategoryType} 한국어 제목에 해당하는 커뮤니티 카테고리 (영문)
- * @throws {Error} 유효하지 않은 제목일 경우 에러 발생
+ * @param {CommunityCategoryType} category - 커뮤니티 카테고리 (영문)
+ * @returns {string} 커뮤니티 카테고리에 해당하는 이모지
+ * @throws {Error} 유효하지 않은 카테고리일 경우 에러 발생
  */
-export function titleToCategory(
-  title: CommunityCategoryKorType,
-): CommunityCategoryType {
-  const categoryKorMap: Record<
-    CommunityCategoryKorType,
-    CommunityCategoryType
-  > = {
-    공지사항: 'notice',
-    자유: 'free',
-    QnA: 'qna',
-    졸업생: 'graduated',
-    'IT 뉴스': 'news',
-    '채용 정보': 'hire',
-    소식: 'organization',
-  };
-
-  if (title in categoryKorMap) {
-    return categoryKorMap[title];
+export function getCategoryEmoji(category: CommunityCategoryType): string {
+  if (category in CATEGORY_MAP) {
+    return CATEGORY_MAP[category].emoji;
   }
-
-  throw new Error(`Invalid title: ${title}`);
+  throw new Error(`Invalid category emoji: ${category}`);
 }
 /**
  * 주어진 문자열이 유효한 커뮤니티 카테고리 타입인지 확인합니다.


### PR DESCRIPTION
## Summary

커뮤니티 UI를 개선합니다.

## Tasks

- 게시글 제목에 댓글을 추가했어요. 7f87cb0b2beee67021cb3b3cb023690a7646131c
- 모아보기에 썸네일이 있을 경우 표시 되도록 수정했어요. 1f590e27c6936c385c77334a521d23d02c3c2445
- 게시글이 로딩 상태일 때 스켈레톤이 표시 되도록 추가했어요. b0b9002671c8546c041a41d2275369c37dec9dcc
- 개발 환경을 경우 네비바의 하단 테두리 색을 주황색으로 표시하여 개발 환경인 것을 직관적이게 확인할 수 있도록 했어요. 28719cbe1d63bac20a502262d3db667915f4b231
- 카테고리 관련 함수를 최적화 했어요. 5f0f1798dda0524457295d483a4371492ffd0f01

## ETC

- `useBoards` 훅을 `useSuspenseInfiniteQuery`(무한 스크롤 방식)으로 변경했어요. 5972c5990550776599e2b34393c5186f6a44c695

## Screenshot

| 게시글 댓글 표시 | 모아보기 썸네일 | 게시글 스켈레톤 |
| --- | --- | --- |
|<img width="456" alt="image" src="https://github.com/KGU-C-Lab/clab.page/assets/39869096/e0fb9d9c-7249-4be9-80f9-47a0aa105b62">|<img width="923" alt="image" src="https://github.com/KGU-C-Lab/clab.page/assets/39869096/6b2d689b-79d4-477d-affe-4a00b5c0499d">|<img width="742" alt="image" src="https://github.com/KGU-C-Lab/clab.page/assets/39869096/225ad4ce-c06c-4e16-9f21-5673f4f80060">|

