### PR TITLE
icon, ds패키지 빌드 개선과정 중 ci 에러 수정

### DIFF
--- a/packages/icon/renew.bash
+++ b/packages/icon/renew.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 BASE_DIR="src"
 SUB_DIRS=("color" "outline" "solid")
 SUB_SUB_DIRS=("svg" "react")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
 
   packages/design-system:
     dependencies:
+      '@clab/icon':
+        specifier: workspace:^
+        version: link:../icon
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
## Summary

#183 icon 컴포넌트 생성 건너뛰기

- 어제 올렸던 PR에서 발생했던 ci 에러를 수정했습니다.

## Tasks

- `icon`에 존재하던 `renew.bash`에 누락된 shebang 구문 추가